### PR TITLE
Fix path cleanup for git statuses

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -125,4 +125,12 @@ impl Git {
     {
         self.repository.is_path_ignored(path)
     }
+
+    /// Gets the root directory of the git repository's working tree.
+    ///
+    /// Returns `None` for bare repositories.
+    #[inline]
+    pub fn root_dir(&self) -> Option<&Path> {
+        self.repository.workdir()
+    }
 }


### PR DESCRIPTION
Path cleanup was removing the root directory, which only really worked
when the root directory was the git work tree's root directory. This
resolves the full path to the git working tree, then strips that from
the canonical path to the file.
