### PR TITLE
Add icon for common image formats

### DIFF
--- a/src/icons/mod.rs
+++ b/src/icons/mod.rs
@@ -94,14 +94,16 @@ mod shared {
 
 #[cfg(test)]
 mod tests {
-    use super::for_path;
-    use super::shared;
+    use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn uses_image_icon_for_common_image_extensions() {
-        for ext in ["gif", "jpeg", "jpg", "png"] {
-            let filename = format!("example.{ext}");
-            assert_eq!(for_path(&filename), Some(shared::IMAGE));
-        }
+    #[rstest]
+    #[case("gif")]
+    #[case("jpeg")]
+    #[case("jpg")]
+    #[case("png")]
+    fn uses_image_icon_for_common_image_extensions(#[case] ext: &str) {
+        let filename = format!("example.{ext}");
+        assert_eq!(shared::IMAGE, for_path(&filename).unwrap());
     }
 }


### PR DESCRIPTION
## Summary
- add a shared image icon and map gif/jpeg/jpg/png extensions to it
- add a regression test to ensure image extensions resolve to the icon

## Rationale
- issue #40 requests icons/colors for `.jpeg`, `.png`, `.gif`; `.jpg` was added alongside for completeness

## Testing
- fork CI on cnaples79/fancy-tree passed (cargo test)
- local `cargo test` could not run on this machine due to rustc 1.90 vs project requirement (>=1.92)

Fixes #40